### PR TITLE
coc only

### DIFF
--- a/linux/shell/vim/.vimrc
+++ b/linux/shell/vim/.vimrc
@@ -5,9 +5,7 @@ call plug#begin('~/.vim/plugged')
 " ---
 " DevTools:
 
-" Linting
-Plug 'w0rp/ale'
-" Languages Server(LSP & Autocompletion)
+" Linting & Languages Server(LSP & Autocompletion)
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 " ---
 

--- a/linux/shell/vim/.vimrc
+++ b/linux/shell/vim/.vimrc
@@ -62,6 +62,9 @@ Plug 'yasuhiroki/github-actions-yaml.vim'
 Plug 'lervag/vimtex'
 " Latex conceal improvements
 Plug 'KeitaNakamura/tex-conceal.vim', {'for': 'tex'}
+
+" Golang
+Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
 " --
 
 "---
@@ -115,8 +118,8 @@ Plug 'tiagofumo/vim-nerdtree-syntax-highlight'
 call plug#end()
 
 " Source External configuration
-source ~/.vim/plugin-config.vimrc
-source ~/.vim/plugin-keys.vimrc
 source ~/.vim/config.vimrc
 source ~/.vim/styles.vimrc
 source ~/.vim/keys.vimrc
+source ~/.vim/plugin-config.vimrc
+source ~/.vim/plugin-keys.vimrc

--- a/linux/shell/vim/.vimrc
+++ b/linux/shell/vim/.vimrc
@@ -45,6 +45,8 @@ Plug 'ryanoasis/vim-devicons'
 " Language specific plugins:
 
 " Syntax & co for all languages
+"  Polygplot when using custom language packs
+let g:polyglot_disabled = ['typescript']
 Plug 'sheerun/vim-polyglot'
 
 " markdown preview

--- a/linux/shell/vim/plugin-config.vimrc
+++ b/linux/shell/vim/plugin-config.vimrc
@@ -2,7 +2,7 @@
 
 " ---
 " Ultisnips
-"Snippets engine
+" Snippets engine
 let g:go_snippet_engine = "ultisnips"
 let g:UltiSnipsEditSplit="vertical"
 let g:UltiSnipsExpandTrigger="<c-j>"
@@ -78,7 +78,7 @@ autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in
 
 " ---
 " Autosave
-let g:auto_save = 0  " enable AutoSave on Vim startup
+let g:auto_save = 1  " enable AutoSave on Vim startup
 let g:auto_save_in_insert_mode = 0  " do not save while in insert mode
 " ---
 
@@ -104,7 +104,7 @@ endif
 " coc.nvim
 
 " coc extensions
-let g:coc_global_extensions = ['coc-tsserver', 'coc-prettier', 'coc-eslint', 'coc-snippets', 'coc-json', 'coc-yank']
+let g:coc_global_extensions = ['coc-tsserver', 'coc-prettier', 'coc-eslint', 'coc-snippets', 'coc-json', 'coc-yank', 'coc-go']
 " if hidden is not set, TextEdit might fail.
 set hidden
 " Better display for messages
@@ -113,14 +113,17 @@ set hidden
 set updatetime=300
 " don't give |ins-completion-menu| messages.
 set shortmess+=c
+
+" TODO this does not work. Probably due to relative numbers or so.
 " Always show the signcolumn, otherwise it would shift the text each time
 " diagnostics appear/become resolved.
-if has("nvim-0.5.0") || has("patch-8.1.1564")
-  " Recently vim can merge signcolumn and number column into one
-  set signcolumn=number
-else
-  set signcolumn=yes
-endif
+" if has("nvim-0.5.0") || has("patch-8.1.1564")
+"   " Recently vim can merge signcolumn and number column into one
+  " set signcolumn=number
+" else
+  " set signcolumn=yes
+" endif
+set signcolumn=yes
 " ---
 
 " ---
@@ -142,4 +145,15 @@ au BufReadPost *.ts set syntax=javascript
 " ---
 " Markdown preview
 let g:instant_markdown_autostart = 0
+" ---
+
+" ---
+"  Golang config
+" go-vim plugin specific commands
+" Also run `goimports` on your current file on every save
+" Might be be slow on large codebases, if so, just comment it out
+let g:go_fmt_command = "goimports"
+
+" Status line types/signatures.
+let g:go_auto_type_info = 1
 " ---

--- a/linux/shell/vim/plugin-config.vimrc
+++ b/linux/shell/vim/plugin-config.vimrc
@@ -104,7 +104,7 @@ endif
 " coc.nvim
 
 " coc extensions
-let g:coc_global_extensions = ['coc-tsserver', ]
+let g:coc_global_extensions = ['coc-tsserver', 'coc-prettier', 'coc-eslint', 'coc-snippets', 'coc-json', 'coc-yank']
 " if hidden is not set, TextEdit might fail.
 set hidden
 " Better display for messages
@@ -113,8 +113,14 @@ set hidden
 set updatetime=300
 " don't give |ins-completion-menu| messages.
 set shortmess+=c
-" always show signcolumns
-set signcolumn=yes
+" Always show the signcolumn, otherwise it would shift the text each time
+" diagnostics appear/become resolved.
+if has("nvim-0.5.0") || has("patch-8.1.1564")
+  " Recently vim can merge signcolumn and number column into one
+  set signcolumn=number
+else
+  set signcolumn=yes
+endif
 " ---
 
 " ---
@@ -126,6 +132,11 @@ set splitbelow
 " Commentary
 " Use right comments markdown(neovim related?: https://github.com/tpope/vim-commentary/issues/90)
 autocmd FileType markdown setlocal commentstring=<!--\ %s\ -->
+" ---
+
+" ---
+" Set js syntax for ts as it works better
+au BufReadPost *.ts set syntax=javascript
 " ---
 
 " ---

--- a/linux/shell/vim/plugin-config.vimrc
+++ b/linux/shell/vim/plugin-config.vimrc
@@ -86,7 +86,6 @@ let g:auto_save_in_insert_mode = 0  " do not save while in insert mode
 " vim-airline
 let g:airline_theme = 'powerlineish'
 let g:airline#extensions#branch#enabled = 1
-let g:airline#extensions#ale#enabled = 1
 let g:airline#extensions#tabline#enabled = 1
 let g:airline#extensions#tabline#ignore_bufadd_pat =
   \ 'gundo|undotree|vimfiler|tagbar|nerd_tree|startify|!'
@@ -105,7 +104,7 @@ endif
 " coc.nvim
 
 " coc extensions
-let g:coc_global_extensions = []
+let g:coc_global_extensions = ['coc-tsserver', ]
 " if hidden is not set, TextEdit might fail.
 set hidden
 " Better display for messages
@@ -116,26 +115,6 @@ set updatetime=300
 set shortmess+=c
 " always show signcolumns
 set signcolumn=yes
-" ---
-
-" ---
-" Ale
-let g:ale_sign_error = '⤫'
-let g:ale_sign_warning = '⚠'
-let g:ale_linters_explicit = 1
-let g:ale_lint_on_text_changed = 0
-let g:ale_lint_on_save = 1
-" Ale fix
-let g:ale_fix_on_save = 0
-let g:ale_linters = {
- \   'latex': ['lacheck', 'chktex', 'Proselint'],
- \   'javascript': ['standard', 'prettier']
-\}
-let g:ale_fixers = {
-\   'javascript': ['prettier', 'standard'],
-\   'css': ['prettier'],
-\   'latex': ['lacheck', 'chktex', 'Proselint'],
-\}
 " ---
 
 " ---

--- a/linux/shell/vim/plugin-keys.vimrc
+++ b/linux/shell/vim/plugin-keys.vimrc
@@ -8,7 +8,7 @@ if executable('rg')
   command! -bang -nargs=* Find call fzf#vim#grep('rg --column --line-number --no-heading --fixed-strings --ignore-case --hidden --follow --glob "!.git/*" --color "always" '.shellescape(<q-args>).'| tr -d "\017"', 1, <bang>0)
 endif
 cnoremap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
-nnoremap <silent> <leader>b :Buffers<CR>
+nnoremap <Leader>b :Buffers<CR>
 "Recovery commands from history through FZF
 nmap <leader>y :History:<CR>
 nnoremap <C-p> :Files<CR>
@@ -179,6 +179,8 @@ nmap <silent> <F4> :TagbarToggle<CR>
 let g:tagbar_autofocus = 1
 " Goyo
 autocmd! User GoyoEnter Limelight
+" TODO review commands below as they do not seem to work
+" :Buffers with ,b f.ex also not getting loaded???
 "" Vimux
 " Prompt for a command to run
 map <Leader>tp :VimuxPromptCommand<CR>

--- a/linux/shell/vim/plugin-keys.vimrc
+++ b/linux/shell/vim/plugin-keys.vimrc
@@ -152,16 +152,6 @@ inoremap <silent><expr> <c-space> coc#refresh()
 " ---
 
 " ---
-" Ale
-" Show errors on <leader>e
-nnoremap <leader>e :ALEDetail<cr>
-" Shortcut to fix errors
-nmap <leader>d <Plug>(ale_fix)
-nmap <silent> [c <Plug>(ale_previous_wrap)
-nmap <silent> ]c <Plug>(ale_next_wrap)
-" ---
-
-" ---
 " Misc:
 
 " Snippets

--- a/linux/shell/vim/plugin-keys.vimrc
+++ b/linux/shell/vim/plugin-keys.vimrc
@@ -8,7 +8,6 @@ if executable('rg')
   command! -bang -nargs=* Find call fzf#vim#grep('rg --column --line-number --no-heading --fixed-strings --ignore-case --hidden --follow --glob "!.git/*" --color "always" '.shellescape(<q-args>).'| tr -d "\017"', 1, <bang>0)
 endif
 cnoremap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
-" TODO get them working properly
 nnoremap <silent> <leader>b :Buffers<CR>
 "Recovery commands from history through FZF
 nmap <leader>y :History:<CR>
@@ -53,110 +52,128 @@ function! s:check_back_space() abort
   return !col || getline('.')[col - 1]  =~# '\s'
 endfunction
 
-" Remap for format selected region
-vmap <leader>f  <Plug>(coc-format-selected)
-nmap <leader>f  <Plug>(coc-format-selected)
-" Show all diagnostics
-nnoremap <silent> <space>a  :<C-u>CocList diagnostics<cr>
-" Manage extensions
-nnoremap <silent> <space>e  :<C-u>CocList extensions<cr>
-" Show commands
-nnoremap <silent> <space>c  :<C-u>CocList commands<cr>
-" Find symbol of current document
-nnoremap <silent> <space>o  :<C-u>CocList outline<cr>
-" Search workspace symbols
-nnoremap <silent> <space>s  :<C-u>CocList -I symbols<cr>
-" Do default action for next item.
-nnoremap <silent> <space>j  :<C-u>CocNext<CR>
-" Do default action for previous item.
-nnoremap <silent> <space>k  :<C-u>CocPrev<CR>
-" Resume latest coc list
-nnoremap <silent> <space>p  :<C-u>CocListResume<CR>
 " Use <c-space> to trigger completion.
-inoremap <silent><expr> <c-space> coc#refresh()
+if has('nvim')
+  inoremap <silent><expr> <c-space> coc#refresh()
+else
+  inoremap <silent><expr> <c-@> coc#refresh()
+endif
+
+
+" Make <CR> auto-select the first completion item and notify coc.nvim to
+" format on enter, <cr> could be remapped by other vim plugin
+inoremap <silent><expr> <cr> pumvisible() ? coc#_select_confirm()
+                              \: "\<C-g>u\<CR>\<c-r>=coc#on_enter()\<CR>"
 
 " Use `[g` and `]g` to navigate diagnostics
+" Use `:CocDiagnostics` to get all diagnostics of current buffer in location list.
 nmap <silent> [g <Plug>(coc-diagnostic-prev)
 nmap <silent> ]g <Plug>(coc-diagnostic-next)
 
-" Remap keys for gotos
+" GoTo code navigation.
 nmap <silent> gd <Plug>(coc-definition)
 nmap <silent> gy <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references)
 
-" Remap for rename current word
-nmap <leader>rn <Plug>(coc-rename)
-
-" Remap for format selected region
-nmap <leader>f  <Plug>(coc-format-selected)
-vmap <leader>f  <Plug>(coc-format-selected)
-
-" Remap for do codeAction of selected region, ex: `<leader>aap` for current paragraph
-xmap <leader>a  <Plug>(coc-codeaction-selected)
-nmap <leader>a  <Plug>(coc-codeaction-selected)
-
-" Remap for do codeAction of current line
-nmap <leader>ac  <Plug>(coc-codeaction)
-" Fix autofix problem of current line
-nmap <leader>qf  <Plug>(coc-fix-current)
-
-" Create mappings for function text object, requires document symbols feature of languageserver.
-xmap if <Plug>(coc-funcobj-i)
-xmap af <Plug>(coc-funcobj-a)
-omap if <Plug>(coc-funcobj-i)
-omap af <Plug>(coc-funcobj-a)
-
-" Use `:Format` to format current buffer
-command! -nargs=0 Format :call CocAction('format')
-
-" Use `:Fold` to fold current buffer
-command! -nargs=? Fold :call     CocAction('fold', <f-args>)
-
-" use `:OR` for organize import of current buffer
-command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
-
-" Add status line support, for integration with other plugin, checkout `:h coc-status`
-set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}
-
-" Use K to show documentation in preview window
+" Use K to show documentation in preview window.
 nnoremap <silent> K :call <SID>show_documentation()<CR>
 
 function! s:show_documentation()
-if (index(['vim','help'], &filetype) >= 0)
-execute 'h '.expand('<cword>')
-else
-call CocAction('doHover')
-endif
+  if (index(['vim','help'], &filetype) >= 0)
+    execute 'h '.expand('<cword>')
+  elseif (coc#rpc#ready())
+    call CocActionAsync('doHover')
+  else
+    execute '!' . &keywordprg . " " . expand('<cword>')
+  endif
 endfunction
 
-" Highlight symbol under cursor on CursorHold
+" Highlight the symbol and its references when holding the cursor.
 autocmd CursorHold * silent call CocActionAsync('highlight')
 
-" Use tab for trigger completion with characters ahead and navigate.
-" Use command ':verbose imap <tab>' to make sure tab is not mapped by other plugin.
-inoremap <silent><expr> <TAB>
-\ pumvisible() ? "\<C-n>" :
-\ <SID>check_back_space() ? "\<TAB>" :
-\ coc#refresh()
-inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+" Symbol renaming.
+nmap <leader>rn <Plug>(coc-rename)
 
-function! s:check_back_space() abort
-let col = col('.') - 1
-return !col || getline('.')[col - 1]  =~# '\s'
-endfunction
+" Formatting selected code.
+xmap <leader>f  <Plug>(coc-format-selected)
+nmap <leader>f  <Plug>(coc-format-selected)
 
-" Use <c-space> to trigger completion.
-" TODO change as it conflicts with TMUX
-inoremap <silent><expr> <c-space> coc#refresh()
+augroup mygroup
+  autocmd!
+  " Setup formatexpr specified filetype(s).
+  autocmd FileType typescript,json setl formatexpr=CocAction('formatSelected')
+  " Update signature help on jump placeholder.
+  autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
+augroup end
+
+" Applying codeAction to the selected region.
+" Example: `<leader>aap` for current paragraph
+xmap <leader>a  <Plug>(coc-codeaction-selected)
+nmap <leader>a  <Plug>(coc-codeaction-selected)
+
+" Remap keys for applying codeAction to the current buffer.
+nmap <leader>ac  <Plug>(coc-codeaction)
+" Apply AutoFix to problem on the current line.
+nmap <leader>qf  <Plug>(coc-fix-current)
+
+" Map function and class text objects
+" NOTE: Requires 'textDocument.documentSymbol' support from the language server.
+xmap if <Plug>(coc-funcobj-i)
+omap if <Plug>(coc-funcobj-i)
+xmap af <Plug>(coc-funcobj-a)
+omap af <Plug>(coc-funcobj-a)
+xmap ic <Plug>(coc-classobj-i)
+omap ic <Plug>(coc-classobj-i)
+xmap ac <Plug>(coc-classobj-a)
+omap ac <Plug>(coc-classobj-a)
+
+" Remap <C-f> and <C-b> for scroll float windows/popups.
+if has('nvim-0.4.0') || has('patch-8.2.0750')
+  nnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
+  nnoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#scroll(0) : "\<C-b>"
+  inoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? "\<c-r>=coc#float#scroll(1)\<cr>" : "\<Right>"
+  inoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? "\<c-r>=coc#float#scroll(0)\<cr>" : "\<Left>"
+  vnoremap <silent><nowait><expr> <C-f> coc#float#has_scroll() ? coc#float#scroll(1) : "\<C-f>"
+  vnoremap <silent><nowait><expr> <C-b> coc#float#has_scroll() ? coc#float#scroll(0) : "\<C-b>"
+endif
+
+" Use CTRL-S for selections ranges.
+" Requires 'textDocument/selectionRange' support of language server.
+nmap <silent> <C-s> <Plug>(coc-range-select)
+xmap <silent> <C-s> <Plug>(coc-range-select)
+
+" Add `:Format` command to format current buffer.
+command! -nargs=0 Format :call CocAction('format')
+
+" Add `:Fold` command to fold current buffer.
+command! -nargs=? Fold :call     CocAction('fold', <f-args>)
+
+" Add `:OR` command for organize imports of the current buffer.
+command! -nargs=0 OR   :call     CocAction('runCommand', 'editor.action.organizeImport')
+
+" Mappings for CoCList
+" Show all diagnostics.
+nnoremap <silent><nowait> <space>a  :<C-u>CocList diagnostics<cr>
+" Manage extensions.
+nnoremap <silent><nowait> <space>e  :<C-u>CocList extensions<cr>
+" Show commands.
+nnoremap <silent><nowait> <space>c  :<C-u>CocList commands<cr>
+" Find symbol of current document.
+nnoremap <silent><nowait> <space>o  :<C-u>CocList outline<cr>
+" Search workspace symbols.
+nnoremap <silent><nowait> <space>s  :<C-u>CocList -I symbols<cr>
+" Do default action for next item.
+nnoremap <silent><nowait> <space>j  :<C-u>CocNext<CR>
+" Do default action for previous item.
+nnoremap <silent><nowait> <space>k  :<C-u>CocPrev<CR>
+" Resume latest coc list.
+nnoremap <silent><nowait> <space>p  :<C-u>CocListResume<CR>
 " ---
 
 " ---
 " Misc:
 
-" Snippets
-" Open UltiSnips edit function
-nmap <leader>ue :UltiSnipsEdit<cr>
 " Tagbar
 nmap <silent> <F4> :TagbarToggle<CR>
 let g:tagbar_autofocus = 1
@@ -172,8 +189,6 @@ nnoremap <leader>tr :10Term<CR>
 " Build in terminal
 tnoremap <Esc> <C-\><C-n>
 nnoremap <leader>it :terminal<CR>
-" ctags
-nmap <F8> :TagbarToggle<CR>
 " vimtex and latex conf
 inoremap <C-f> <Esc>: silent exec '.!inkscape-figures create "'.getline('.').'" "'.b:vimtex.root.'/figures/"'<CR><CR>:w<CR>
 nnoremap <C-f> : silent exec '!inkscape-figures edit "'.b:vimtex.root.'/figures/" > /dev/null 2>&1 &'<CR><CR>:redraw!<CR>

--- a/linux/system/kitty/kitty.conf
+++ b/linux/system/kitty/kitty.conf
@@ -17,7 +17,7 @@ bold_font        JetBrains Mono ExtraBold
 italic_font      JetBrains Mono Italic
 bold_italic_font JetBrains Mono Bold Italic
 
-font_size 14.0
+font_size 11.0
 disable_ligatures never
 
 # CURSOR


### PR DESCRIPTION
> Test with only using coc as LSP/Linter/Formatter/...

- Use coc only
- Use smaller font size in terminal
- Config. coc extensions  and use js syntax for ts as it works better
- Config coc keys and some clean up
- Fix plugin mappings probably getting overwritten through the default ones and add go support
